### PR TITLE
Prevent associations with order scopes from failing

### DIFF
--- a/lib/active_median/model.rb
+++ b/lib/active_median/model.rb
@@ -66,7 +66,7 @@ module ActiveMedian
           raise "Connection adapter not supported: #{connection.adapter_name}"
         end
 
-      result = connection.select_all(relation.to_sql)
+      result = connection.select_all(relation.except(:order).to_sql)
 
       # typecast
       rows = []

--- a/test/median_test.rb
+++ b/test/median_test.rb
@@ -87,6 +87,12 @@ class MedianTest < Minitest::Test
     assert_equal 1, user.posts.median(:comments_count)
   end
 
+  def test_ordered_association
+    user = User.create!
+    user.posts.create!(comments_count: 1)
+    assert_equal 1, user.ordered_posts.median(:comments_count)
+  end
+
   def test_references
     user = User.create!
     user.posts.create!(comments_count: 1)

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -30,10 +30,12 @@ end
 ActiveRecord::Migration.create_table :posts, force: true do |t|
   t.references :user
   t.integer :comments_count
+  t.datetime :created_at
 end
 
 class User < ActiveRecord::Base
   has_many :posts
+  has_many :ordered_posts, -> { order('created_at asc') }, class_name: 'Post'
 end
 
 class Post < ActiveRecord::Base


### PR DESCRIPTION
The following code fails on `master`:

```ruby
class Post < ActiveRecord::Base
end

class User < ActiveRecord::Base
  has_many :posts, -> { order('created_at asc') }, class_name: 'Post'
end

User.first.posts.median(:comments_count)
# => ActiveRecord::StatementInvalid: PG::GroupingError: ERROR:  column "posts.created_at" must appear in the GROUP BY clause or be used in an aggregate function...
```

This PR fixes that by removing the `order` scope on the percentile query.